### PR TITLE
Fix printing non-existent bytes at end of file

### DIFF
--- a/bgrep.c
+++ b/bgrep.c
@@ -111,7 +111,7 @@ void dump_context(int fd, unsigned long long pos)
 			die("Error reading context");
 		}
 
-		char* buf_end = buf + read_chunk;
+		char* buf_end = buf + bytes_read;
 		char* p = buf;
 
 		for (; p < buf_end;p++)


### PR DESCRIPTION
This commit fixes an edge case where the contents of buf are printed,
even though those contents were never read from the file.

This issue was encountered while using the -A option with a match found
near the end of a file. Whatever contents were previously in buf were
printed, which is misleading since they didn't exist in the file.
