### PR TITLE
No need to install system-wide

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ Feel free to modify, branch, fork, improve. Re-licenses as BSD.
 
 To install:
 
-curl -L 'https://github.com/tmbinc/bgrep/raw/master/bgrep.c' | gcc -O2 -x c -o /usr/local/bin/bgrep -
+curl -L 'https://github.com/tmbinc/bgrep/raw/master/bgrep.c' | gcc -O2 -x c -o $HOME/.local/bin/bgrep -
 
 usage:
 


### PR DESCRIPTION
Change the `/usr/local/` suggestion (which would lack `sudo` or `su`) for `$HOME/.local`