### PR TITLE
Support External Pattern & Mask Files

### DIFF
--- a/test/bgrep-test.sh
+++ b/test/bgrep-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+readonly SCRIPT_PATH="$(dirname "$0")"
+
 PREPARE=1
 
 if [ $# -gt 0 ];then
@@ -37,10 +39,27 @@ fi
 # Test execution
 #
 echo Testing bgrep
-echo "../bgrep 424242 /tmp/bgrepTest* | sed 's/^.*: //g' > /tmp/results.txt"
+echo "${SCRIPT_PATH}/../bgrep 424242 /tmp/bgrepTest* | sed 's/^.*: //g' > /tmp/results.txt"
 
-../bgrep 424242 /tmp/bgrepTest* | sed 's/^.*: //g' > /tmp/results.txt
+"${SCRIPT_PATH}"/../bgrep 424242 /tmp/bgrepTest* | sed 's/^.*: //g' > /tmp/results.txt
 
-echo -e "\nDifferences between /tmp/results.txt and /tmp/bgrepExpectedResult.txt:"
+echo -e "\nDifferences between /tmp/results.txt and /tmp/bgrepExpectedResult.txt (arg):"
 
-diff -u /tmp/results.txt /tmp/bgrepExpectedResult.txt
+diff -u /tmp/results.txt /tmp/bgrepExpectedResult.txt || exit 1
+
+echo "424242" | xxd -p -r > /tmp/bgrep-pattern
+
+"${SCRIPT_PATH}"/../bgrep -f /tmp/bgrep-pattern /tmp/bgrepTest* | sed 's/^.*: //g' > /tmp/results.txt
+
+echo -e "\nDifferences between /tmp/results.txt and /tmp/bgrepExpectedResult.txt (file):"
+
+diff -u /tmp/results.txt /tmp/bgrepExpectedResult.txt || exit 1
+
+echo "424242" | xxd -p -r > /tmp/bgrep-pattern
+echo "FFFFFF" | xxd -p -r > /tmp/bgrep-mask
+
+"${SCRIPT_PATH}"/../bgrep -f /tmp/bgrep-pattern -m /tmp/bgrep-mask /tmp/bgrepTest* | sed 's/^.*: //g' > /tmp/results.txt
+
+echo -e "\nDifferences between /tmp/results.txt and /tmp/bgrepExpectedResult.txt (file+mask):"
+
+diff -u /tmp/results.txt /tmp/bgrepExpectedResult.txt || exit 1


### PR DESCRIPTION
Adds support for external pattern and mask files with the `-f` and `-m` arguments, respectively. Both files are expected to be binary files containing the bits to be matched. Files are read in byte order (any endianness must be taken care of by the creator). At the moment, `-m` is only available with `-f`, but that is not a strict limitation.

Increases the default buffer size to 1MB to increase throughput. For the tested use case this reduced processing time by half.

Adds an `-r` option to enable recursion to match POSIX grep.

Fixes an off-by-one error when allocating space for the next path when recursing.

Adds additional tests for using a pattern file as well as a pattern file with a mask. Test failures now terminate early with a non-zero exit code. `bgrep-test.sh` can now be run from any directory (such as the project root).