### PR TITLE
Fix wrong match offset

### DIFF
--- a/bgrep.c
+++ b/bgrep.c
@@ -183,7 +183,7 @@ void searchfile(const char *filename, int fd, const unsigned char *value, const 
 			}
 		}
 
-		offset += o;
+		offset += r;
 	}
 
 	free(buf);


### PR DESCRIPTION
This happens when the search pattern size is bigger than half the search buffer size. In this case, when `offset` is 0 (during the first `while` iteration), `o` is set to `len`, which is bigger than `r` (=`bufsize - len`), so the loop is bypassed and `offset` is then set to `len` instead of the number of bytes read (=`r`).

The tests scripts cannot show that because the search pattern is always too small (it needs to be at least 512 KB since the minimum buffer size is 1 MB).

This bug was introduced with PR #21. I don't understand why this PR changed that code.