### PR TITLE
bgrep: clarify -A, -B, -C

### DIFF
--- a/bgrep.1
+++ b/bgrep.1
@@ -32,13 +32,17 @@ if present, the mask will be ANDed before the comparison.
 .SH OPTIONS
 .TP
 .BR \-B " <bytes>"
-print <bytes> of context before each match
+print <bytes> immediately before the match offset
 .TP
 .BR \-A " <bytes>"
-print <bytes> of context after each match
+print <bytes> starting at the match offset. The window begins at the match, so
+it covers the matched bytes first; to see N bytes following an M-byte pattern,
+use
+.BR \-A " (M+N)."
 .TP
 .BR \-C " <bytes>"
-print <bytes> of context before and after a match
+print <bytes> before the match and <bytes> after it, with the matched bytes
+shown in between
 .TP
 .B \-r
 recurse into directories
@@ -50,10 +54,14 @@ read the search pattern (in binary) from a file instead of <hex>
 read a mask file
 .SH OUTPUT
 Each match is printed as the file name, a colon, and the zero-padded
-hexadecimal offset of the match, one per line. Context bytes requested with
-.BR \-A ", " \-B ", or " \-C
-are dumped below it; printable bytes are shown as-is and others as
+hexadecimal offset of the match, one per line. When context is requested with
+.BR \-A ", " \-B ", or " \-C ,
+the surrounding bytes are dumped on the following line; printable bytes are
+shown as-is and others as
 .BR \(rsxNN .
+See
+.B OPTIONS
+for exactly which bytes each flag includes.
 .SH EXIT STATUS
 .B bgrep
 exits 0 when it runs successfully, whether or not a match was found. It exits

--- a/bgrep.c
+++ b/bgrep.c
@@ -51,6 +51,7 @@
 #endif
 
 int bytes_before = 0, bytes_after = 0;
+bool surround_match = false;
 char **original_argv;
 
 void err(int eval, const char *msg, ...);
@@ -86,7 +87,7 @@ int ascii2hex(char c)
  * 	 we have to maintain a window of the bytes before which I am too lazy to do
  * 	 right now.
  */
-void dump_context(int fd, unsigned long long pos)
+void dump_context(int fd, unsigned long long pos, int match_len)
 {
 	off_t save_pos = lseek(fd, 0, SEEK_CUR);
 
@@ -100,7 +101,7 @@ void dump_context(int fd, unsigned long long pos)
 	// Ensure we don't attempt to dump from before the file for a context dump.
 	int before = (pos < (unsigned long long)bytes_before) ? (int)pos : bytes_before;
 	off_t start = pos - before;
-	int bytes_to_read = before + bytes_after;
+	int bytes_to_read = before + bytes_after + (surround_match ? match_len : 0);
 
 	if (lseek(fd, start, SEEK_SET) == (off_t)-1)
 	{
@@ -186,7 +187,7 @@ void searchfile(const char *filename, int fd, const unsigned char *value, const 
 				unsigned long long pos = (unsigned long long)(offset + o - len);
 				printf("%s: %08llx\n", filename, pos);
 				if (bytes_before || bytes_after)
-					dump_context(fd, pos);
+					dump_context(fd, pos, len + 1);
 			}
 		}
 
@@ -304,6 +305,7 @@ void parse_opts(int argc, char **argv, Options *options)
 				break;
 			case 'C':
 				bytes_before = bytes_after = atoi(optarg);
+				surround_match = true;
 				break;
 			case 'f':
 				options->pattern_path = optarg;


### PR DESCRIPTION
Clarify the context of -A, -B and -C:

 - -A <x> will show <x> bytes from the start of the match. (Not end of the match!)
 - -B <x> will show <x> bytes before the match.
 - -C <x> will show <x> bytes before the match, the match itself, and <x> bytes after the match.
